### PR TITLE
Fix: allow setting any model as default

### DIFF
--- a/05_settingsManager.js
+++ b/05_settingsManager.js
@@ -153,9 +153,19 @@ function removeProviderApiKey(provider) {
 function setDefaultModel(modelName) {
   try {
     const propertyStore = getPropertyStore();
-    const availableModels = getModelConfig().available;
-    
-    if (!availableModels.includes(modelName)) {
+    const config = getModelConfig();
+    // Flatten all models from all providers into a single array
+    const allModels = [
+      ...config.all.gemini,
+      ...config.all.openai,
+      ...config.all.anthropic
+    ];
+
+    // Debug logging
+    Logger.log('setDefaultModel called with: %s', modelName);
+    Logger.log('All models: %s', JSON.stringify(allModels));
+
+    if (!allModels.includes(modelName)) {
       return { success: false, message: `Invalid model: ${modelName}` };
     }
     


### PR DESCRIPTION
The changes enable the selection of any available model as the default, addressing the issue where GPT models were erroring out. The function now flattens all models from various providers into a single array for validation. This ensures that the AI_CALL function can process queries using the correct model.

Fixes #15